### PR TITLE
Example with Pomerium as auth

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,27 @@
+authenticate_service_url: https://authenticate.pomerium.app
+
+####################################################################################
+# If self-hosting, you must configure an identity provider.                        #
+# See identity provider settings: https://www.pomerium.com/docs/identity-providers/#
+####################################################################################
+jwt_claim_headers: email
+# https://pomerium.com/reference/#routes
+routes:
+  - from: https://foo.localhost.pomerium.io
+    to: http://httpbin:80
+    policy:
+      - allow:
+          or:
+            - email:
+                is: gaurdro@gaurdro.net
+    pass_identity_headers: true
+    jwt_claims_headers: email,user
+  - from: https://verify.localhost.pomerium.io
+    to: http://guacamole:8080
+    policy:
+      - allow:
+          or:
+            - email:
+                is: gaurdro@gaurdro.net
+    pass_identity_headers: true
+    jwt_claims_headers: email

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -130,10 +130,13 @@ services:
     - postgres
     environment:
       GUACD_HOSTNAME: guacd
-      POSTGRES_DATABASE: guacamole_db
-      POSTGRES_HOSTNAME: postgres
-      POSTGRES_PASSWORD: 'ChooseYourOwnPasswordHere1234'
-      POSTGRES_USER: guacamole_user
+      POSTGRESQL_DATABASE: guacamole_db
+      POSTGRESQL_HOSTNAME: postgres
+      POSTGRESQL_PASSWORD: 'ChooseYourOwnPasswordHere1234'
+      POSTGRESQL_USER: guacamole_user
+      HEADER_ENABLED: true
+      HTTP_AUTH_HEADER: X-Pomerium-Claim-Email
+      LOGBACK_LEVEL: trace
     image: guacamole/guacamole
     networks:
       - guacnetwork_compose
@@ -146,18 +149,37 @@ services:
     - 8080/tcp
     restart: always
 
+########### Pomerium core ########
+  httpbin:
+    image: kennethreitz/httpbin 
+    ports: 
+      - 80:80
+    networks:
+      - guacnetwork_compose
+  pomerium:
+    image: cr.pomerium.com/pomerium/pomerium:latest
+    volumes:
+      ## Mount your config file: https://www.pomerium.com/docs/reference/
+      - ./config.yaml:/pomerium/config.yaml:ro
+    ports:
+      - 443:443
+    networks:
+      - guacnetwork_compose
+    environment:
+      JWT_CLAIMS_HEADERS: email, groups, user
+
 ########### optional ##############
   # nginx
-  nginx:
-   container_name: nginx_guacamole_compose
-   restart: always
-   image: nginx:latest
-   volumes:
-   - ./nginx/templates:/etc/nginx/templates:ro
-   - ./nginx/ssl/self.cert:/etc/nginx/ssl/self.cert:ro
-   - ./nginx/ssl/self-ssl.key:/etc/nginx/ssl/self-ssl.key:ro
-   ports:
-   - 8443:443
-   networks:
-     - guacnetwork_compose
+#  nginx:
+#   container_name: nginx_guacamole_compose
+#   restart: always
+#   image: nginx:latest
+#   volumes:
+#   - ./nginx/templates:/etc/nginx/templates:ro
+#   - ./nginx/ssl/self.cert:/etc/nginx/ssl/self.cert:ro
+#   - ./nginx/ssl/self-ssl.key:/etc/nginx/ssl/self-ssl.key:ro
+#   ports:
+#   - 8443:443
+#   networks:
+#     - guacnetwork_compose
 ####################################################################################


### PR DESCRIPTION
This is a basic way to get header auth working from pomerium to apache guacamole. 